### PR TITLE
Improve Reliability of RPC Clients

### DIFF
--- a/services/app/app/__main__.py
+++ b/services/app/app/__main__.py
@@ -9,7 +9,7 @@ from app.models.weather import Weather
 server = queue.QueueServer(config.QUEUE_URL, config.QUEUE_TOPIC_APP)
 db = Database(config.DATABASE_URL)
 weather_scraper_client = queue.QueueClient(config.QUEUE_URL, config.QUEUE_TOPIC_WEATHER)
-weather_scraper_client.start()
+
 
 @server.route('Player.create')
 def player_create(payload: dict, metadata: dict) -> Optional[Tuple[int, Union[dict, list]]]:

--- a/services/gateway/gateway/__main__.py
+++ b/services/gateway/gateway/__main__.py
@@ -55,5 +55,4 @@ def protected_example():
     })
 
 
-rpc.start()
 serve(app, host='0.0.0.0', port=80)

--- a/services/gateway/gateway/queue.py
+++ b/services/gateway/gateway/queue.py
@@ -1,96 +1,72 @@
 import json
 import uuid
-from concurrent.futures import Future
-from multiprocessing import Process, Queue
-from threading import Thread
-from typing import Dict
-
-from flask_jwt_extended import get_jwt_claims
+from typing import Optional
 
 import pika
-from flask import Response, jsonify
+from flask import jsonify
+from flask_jwt_extended import get_jwt_claims
 from pika.adapters.blocking_connection import BlockingChannel
 
 
-class QueueConnection(Process):
-    def __init__(self, queue_url: str, queue_app_topic: str):
-        super().__init__(daemon=True, name='queue-connection-process')
+class QueueClientSession:
+    def __init__(
+            self,
+            parameters: Optional[pika.connection.Parameters],
+            request_queue_topic: str
+    ):
+        self.parameters = parameters
+        self.request_queue_topic = request_queue_topic
+        self.connection: Optional[BlockingChannel] = None
+        self.channel: Optional[BlockingChannel] = None
 
-        self.connection = pika.BlockingConnection(pika.URLParameters(queue_url))
+        self.request_queue: Optional[str] = None
+        self.response_queue: Optional[str] = None
+
+    def __enter__(self):
+        self.connection = pika.BlockingConnection(self.parameters)
         self.channel: BlockingChannel = self.connection.channel()
 
         # Setup topic for account
-        request_queue_requests = self.channel.queue_declare(queue=queue_app_topic)
-        request_queue_responses = self.channel.queue_declare(
-            queue='',
-            exclusive=True
-        )
+        self.request_queue = self.channel.queue_declare(queue=self.request_queue_topic).method.queue
+        self.response_queue = self.channel.queue_declare(queue='', exclusive=True).method.queue
 
-        self.request_queue = request_queue_requests.method.queue
-        self.response_queue = request_queue_responses.method.queue
+        return self
 
-        self.channel.basic_consume(
-            queue=self.response_queue,
-            on_message_callback=self.__on_response,
-            auto_ack=True,
-        )
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.channel.queue_delete(self.response_queue)
+        self.channel.close()
+        self.connection.close()
 
-        self.resulting_messages = Queue()
-        self.futures: Dict[str, Future] = {}
 
-        # Copy messages into future dict in main thread
-        self.copy_thread = Thread(target=self.__on_message_main_thread)
-        self.copy_thread.start()
-
-    def __on_message_main_thread(self):
-        while True:
-            correlation_id, body = self.resulting_messages.get(block=True)
-
-            print('Getting response', correlation_id)
-            if correlation_id not in self.futures:
-                print('\tNo known futures')
-                return
-
-            result_future = self.futures[correlation_id]
-
-            try:
-                print('Setting result')
-                result_future.set_result(json.loads(body.decode()))
-            except Exception as e:
-                print('Setting exception')
-                result_future.set_exception(e)
-
-    def __on_response(
-            self,
-            channel: BlockingChannel,
-            method: pika.spec.Basic.Deliver,
-            properties: pika.BasicProperties,
-            body: bytes
-    ):
-        self.resulting_messages.put((properties.correlation_id, body))
+class QueueConnection:
+    def __init__(self, queue_url: str, queue_app_topic: str):
+        self.parameters = pika.URLParameters(queue_url)
+        self.request_queue_topic = queue_app_topic
 
     def __rpc(self, message: dict) -> dict:
         correlation_id = str(uuid.uuid4())
-        self.channel.basic_publish(
-            exchange='',
-            routing_key=self.request_queue,
-            properties=pika.BasicProperties(
-                reply_to=self.response_queue,
-                correlation_id=correlation_id,
-            ),
-            body=json.dumps(message)
-        )
 
-        self.futures[correlation_id] = result_future = Future()
+        with QueueClientSession(self.parameters, self.request_queue_topic) as session:
+            # Publish our message
+            session.channel.basic_publish(
+                exchange='',
+                routing_key=session.request_queue,
+                properties=pika.BasicProperties(
+                    reply_to=session.response_queue,
+                    correlation_id=correlation_id,
+                ),
+                body=json.dumps(message)
+            )
 
-        try:
-            result = result_future.result(timeout=2)
-        except TimeoutError:
-            raise
-        finally:
-            del self.futures[correlation_id]
+            # Read our reply
 
-        return result
+            for deliver, properties, message in session.channel.consume(
+                    queue=session.response_queue,
+                    auto_ack=True,
+                    exclusive=True,
+                    inactivity_timeout=5
+            ):
+                return json.loads(message.decode())
 
     def send(self, method: str, payload: dict, make_jsonified: bool = True):
         response = self.__rpc({
@@ -105,9 +81,3 @@ class QueueConnection(Process):
             body = response['body']
 
         return body, response['statusCode']
-
-    def run(self) -> None:
-        print('Starting queue connection thread')
-        self.channel.start_consuming()
-        self.channel.close()
-        self.connection.close()


### PR DESCRIPTION
The BlockingConnection created by pika is disconnected by RabbitMQ if
there are no messages flowing over the connection. We can either setup
something to periodically send messages or emulate a PHP script and
create a fresh connection every request that needs one. I choose to do
a new connection each request as it simplified a lot of the code and
might remove the need for a correlation id since we can just create an
ephemeral channel that we can delete after the timeout.